### PR TITLE
use indexing to speed up identical polygon removal prior to polygon b…

### DIFF
--- a/csw/jtest/JPolyBool.java
+++ b/csw/jtest/JPolyBool.java
@@ -1158,7 +1158,7 @@ System.out.flush ();
         }
         catch (Throwable ex) {
         }
-        if (nrow > 400) nrow = 400;
+        if (nrow > 200) nrow = 200;
         if (nrow < 3) nrow = 3;
         ncol = nrow;
 


### PR DESCRIPTION
…oolean native calls.  Tested on uniformly distributed polygons and speeds up the identical polygon removal by orders of magnitude for large sets of polygons (> 10000)